### PR TITLE
Fix dependencies for Debian / ubuntu (add make)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Hoedur consists of different main components as listed below:
 ## Getting Started
 
 ### Dependencies
-Ubuntu 18.04:
+Ubuntu 18.04 / Debian 12:
 ```sh
-apt install -y clang curl git libfdt-dev libglib2.0-dev libpixman-1-dev libxcb-shape0-dev libxcb-xfixes0-dev ninja-build patchelf pkg-config python3-psutil zstd
+apt install -y clang curl git libfdt-dev libglib2.0-dev libpixman-1-dev libxcb-shape0-dev libxcb-xfixes0-dev ninja-build patchelf pkg-config python3-psutil zstd make
 ```
 
 ### Install


### PR DESCRIPTION
Went through building today, noticed I was missing `make` on a new Debian VM.

Also specified that these dependencies are for both Ubuntu _and_ Debian.